### PR TITLE
Added sfx tag to the version number

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+collectd (5.5.0-sfx2~trusty) trusty; urgency=low
+
+  * Added sfx as a tag to the collectd version
+
+ -- SignalFx Support <support+deb@signalfx.com>  Wed, 05 Aug 2015 20:33:34 +0000
+
 collectd (5.5.0-sfx1~trusty) trusty; urgency=low
 
   * Complete collectd 5.5.0 build for Ubuntu 14.04

--- a/sfx_scripts/cmdseq.sh
+++ b/sfx_scripts/cmdseq.sh
@@ -15,6 +15,17 @@ patch -p0 < debian/patches/precise_control.patch
 patch -p0 < debian/patches/precise_rules.patch
 fi
 
+#patch version-gen.sh
+VERSION_TAG="$(head -1 debian/changelog | awk -F"[-~]" 'NF>2{print $2}')"
+
+_NEW_VERSION=$(grep DEFAULT_VERSION= version-gen.sh  | awk -F\" '{ print $2; }' | perl -p -e "s/git/$VERSION_TAG/g;")
+cat <<HERE > version-gen.sh
+#!/bin/sh
+printf "$_NEW_VERSION"
+HERE
+
+chmod 755 version-gen.sh
+
 ./build.sh
 DIST=${DISTRIBUTION} ARCH=amd64 yes | debuild -us -uc -S
 rm -rf /opt/mount/pbuilder_results/


### PR DESCRIPTION
When user checks collectd version with "collectd -h" command, sfx tag appears confirming that installation from SignalFx repository as successful.

command: collectd -h
output
collectd 5.5.0.sfx1.1, http://collectd.org/
by Florian octo Forster <octo@collectd.org>