### PR TITLE
Enable debug builds

### DIFF
--- a/build-collectd/debian/rules
+++ b/build-collectd/debian/rules
@@ -74,6 +74,10 @@ ifndef SIGNALFXBUILD
 confflags += --localstatedir=/var --sysconfdir=/etc
 endif
 
+ifdef DEBUG
+confflags += --enable-debug
+endif
+
 # These plugins do not provide any functionality under Linux.
 # MacOS only (requires IO Kit):
 confflags += --disable-apple_sensors

--- a/build-collectd/sfx_scripts/cmdseq
+++ b/build-collectd/sfx_scripts/cmdseq
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -xe
 
+if [ ${1+x} ]; then
+    DEBUG=$1
+    export DEBUG=$DEBUG
+fi
+
 cat /opt/collectd-build/sfx_scripts/pbuilderrc > ~/.pbuilderrc
 
 rm -rf /opt/workspace/*

--- a/build-collectd/sfx_scripts/jenkins-build
+++ b/build-collectd/sfx_scripts/jenkins-build
@@ -10,13 +10,20 @@ if ! [ -z $JOB_NAME ] && ! [ -z $BASE_DIR ]; then
   tempfolder=$(mktemp -d $(pwd)/0.XXXXXX)
   trap "rm -rf $tempfolder; docker rm ${JOB_NAME}" EXIT
   #Build the packages
-  docker run --privileged --name ${JOB_NAME} -e "BUILD_PUBLISH=${BUILD_PUBLISH}" -e "DISTRIBUTION=${DISTRIBUTION}" -t -v ${BASE_DIR}/${JOB_NAME}/collectd:/opt/collectd -v ${BASE_DIR}/${JOB_NAME}/collectd-build-ubuntu/build-collectd:/opt/collectd-build -v ${BASE_DIR}/${JOB_NAME}/workspace:/opt/workspace -v ${BASE_DIR}/${JOB_NAME}/$(basename $tempfolder):/opt/result -v ${BASE_DIR}/${JOB_NAME}/pbuilder:/var/cache/pbuilder quay.io/signalfuse/collectd-build-ubuntu /opt/collectd-build/sfx_scripts/cmdseq
+  docker run --privileged --name ${JOB_NAME} -e "BUILD_PUBLISH=${BUILD_PUBLISH}" -e "DISTRIBUTION=${DISTRIBUTION}" -t -v ${BASE_DIR}/${JOB_NAME}/collectd:/opt/collectd -v ${BASE_DIR}/${JOB_NAME}/collectd-build-ubuntu/build-collectd:/opt/collectd-build -v ${BASE_DIR}/${JOB_NAME}/workspace:/opt/workspace -v ${BASE_DIR}/${JOB_NAME}/$(basename $tempfolder):/opt/result -v ${BASE_DIR}/${JOB_NAME}/pbuilder:/var/cache/pbuilder quay.io/signalfuse/collectd-build-ubuntu /opt/collectd-build/sfx_scripts/cmdseq ${DEBUG}
 
   # create properties file for test job jenkins will kick off
   SCRIPT_DIR=$WORKSPACE/collectd-build-ubuntu/build-collectd/sfx_scripts
   /bin/bash $SCRIPT_DIR/create-jenkinstest-props $SCRIPT_DIR
 
-  S3_BUCKET="s3://public-downloads--signalfuse-com/debs/collectd"
+  S3_BUCKET_ROOT="s3://public-downloads--signalfuse.com"
+
+  if [ ${DEBUG+x} ]; then
+    S3_BUCKET_ROOT="s3://collectd-debug"
+  fi
+
+  S3_BUCKET="${S3_BUCKET_ROOT}/debs/collectd"
+
   if ! [ -z $BUILD_PUBLISH ] && [ $BUILD_PUBLISH = True ]; then
         OUTPUT=$tempfolder
         # Upload the packages and PPA to Amazon S3 bucket


### PR DESCRIPTION
If DEBUG var exists, run configure with --enable-debug.  Upload to a new private S3 bucket (collectd-debug). 