### PR TITLE
Fix bucket name and path

### DIFF
--- a/build-collectd/sfx_scripts/jenkins-build
+++ b/build-collectd/sfx_scripts/jenkins-build
@@ -16,21 +16,21 @@ if ! [ -z $JOB_NAME ] && ! [ -z $BASE_DIR ]; then
   SCRIPT_DIR=$WORKSPACE/collectd-build-ubuntu/build-collectd/sfx_scripts
   /bin/bash $SCRIPT_DIR/create-jenkinstest-props $SCRIPT_DIR
 
-  S3_BUCKET_ROOT="s3://public-downloads--signalfuse-com"
+  S3_BUCKET_ROOT="s3://public-downloads--signalfuse-com/debs/collectd"
 
   if [ ${DEBUG+x} ]; then
-    S3_BUCKET_ROOT="s3://collectd-debug"
+    S3_BUCKET="${S3_BUCKET_ROOT}/${DISTRIBUTION}/debug"
+  else
+    S3_BUCKET="${S3_BUCKET_ROOT}/${DISTRIBUTION}"
   fi
-
-  S3_BUCKET="${S3_BUCKET_ROOT}/debs/collectd"
 
   if ! [ -z $BUILD_PUBLISH ] && [ $BUILD_PUBLISH = True ]; then
         OUTPUT=$tempfolder
         # Upload the packages and PPA to Amazon S3 bucket
-        aws s3 rm --recursive $S3_BUCKET/${DISTRIBUTION}/debuild
-        aws s3 rm --recursive $S3_BUCKET/${DISTRIBUTION}/pdebuild 
-        aws s3 rm --recursive $S3_BUCKET/${DISTRIBUTION}/test
-        aws s3 cp --recursive $OUTPUT $S3_BUCKET/${DISTRIBUTION}
+        aws s3 rm --recursive $S3_BUCKET/debuild
+        aws s3 rm --recursive $S3_BUCKET/pdebuild
+        aws s3 rm --recursive $S3_BUCKET/test
+        aws s3 cp --recursive $OUTPUT $S3_BUCKET
   fi
   exit 0;
 fi


### PR DESCRIPTION
The original idea to put the debug build in its own separate bucket was a bad one so now, put it in the existing bucket under a debug directory

Just a note - this change should not affect anything with the existing buckets - everything else should work as it did before.  Also, i put together this build because we were trying to track down what we thought was a collectd bug but turned out to be a bad salt configuration, but i didn't discover that until after i did this work.  Figured it would be good to push it now that it's finished, but this is not urgent, and can wait for any upcoming releases if you'd like.