### PR TITLE
add no-cache argument to s3 test cp

### DIFF
--- a/build-collectd/sfx_scripts/jenkins-build
+++ b/build-collectd/sfx_scripts/jenkins-build
@@ -30,7 +30,7 @@ if ! [ -z $JOB_NAME ] && ! [ -z $BASE_DIR ]; then
         aws s3 rm --recursive $S3_BUCKET/debuild
         aws s3 rm --recursive $S3_BUCKET/pdebuild
         aws s3 rm --recursive $S3_BUCKET/test
-        aws s3 cp --recursive $OUTPUT $S3_BUCKET
+        aws s3 cp --recursive $OUTPUT $S3_BUCKET --cache-control="max-age=0, no-cache"
   fi
   exit 0;
 fi

--- a/build-collectd/sfx_scripts/promote_beta_to_release.sh
+++ b/build-collectd/sfx_scripts/promote_beta_to_release.sh
@@ -72,7 +72,7 @@ for DISTRIBUTION in ${DEBIAN_OS_ARRAY[@]}
 do
   S3_BUCKET="s3://public-downloads--signalfuse-com/debs/collectd"
   aws s3 rm --recursive $S3_BUCKET/$DISTRIBUTION/release/
-  aws s3 cp --recursive $S3_BUCKET/$DISTRIBUTION/beta/ $S3_BUCKET/$DISTRIBUTION/release/
+  aws s3 cp --recursive $S3_BUCKET/$DISTRIBUTION/beta/ $S3_BUCKET/$DISTRIBUTION/release/ --cache-control="max-age=0, no-cache"
 done
 
 rm -rf /tmp/beta_upgrade

--- a/build-collectd/sfx_scripts/sign_and_upload_to_beta.sh
+++ b/build-collectd/sfx_scripts/sign_and_upload_to_beta.sh
@@ -77,7 +77,7 @@ do
     apt-ftparchive release . > Release
     gpg --default-key $DEBIANKEYID -abs -o Release.gpg Release
     aws s3 rm --recursive $S3_BUCKET/$DISTRIBUTION/beta/
-    aws s3 cp --recursive . $S3_BUCKET/$DISTRIBUTION/beta
+    aws s3 cp --recursive . $S3_BUCKET/$DISTRIBUTION/beta --cache-control="max-age=0, no-cache"
   fi
 done
 rm -rf /tmp/collectd-ppa-uploads/

--- a/build-plugin/sfx_scripts/jenkins-build
+++ b/build-plugin/sfx_scripts/jenkins-build
@@ -34,7 +34,7 @@ if ! [ -z $JOB_NAME ] && ! [ -z $BASE_DIR ]; then
           aws s3 rm --recursive $S3_BUCKET/${DISTRIBUTION}/debuild
           aws s3 rm --recursive $S3_BUCKET/${DISTRIBUTION}/debian
           aws s3 rm --recursive $S3_BUCKET/${DISTRIBUTION}/test
-          aws s3 cp --recursive . $S3_BUCKET/${DISTRIBUTION}
+          aws s3 cp --recursive . $S3_BUCKET/${DISTRIBUTION} --cache-control="max-age=0, no-cache"
           )
         done
         )

--- a/build-plugin/sfx_scripts/promote_beta_to_release.sh
+++ b/build-plugin/sfx_scripts/promote_beta_to_release.sh
@@ -69,7 +69,7 @@ for DISTRIBUTION in ${DEBIAN_OS_ARRAY[@]}
 do
   S3_BUCKET="s3://public-downloads--signalfuse-com/debs/signalfx-collectd-plugin"
   aws s3 rm --recursive $S3_BUCKET/$DISTRIBUTION/release/
-  aws s3 cp --recursive $S3_BUCKET/$DISTRIBUTION/beta/ $S3_BUCKET/$DISTRIBUTION/release/
+  aws s3 cp --recursive $S3_BUCKET/$DISTRIBUTION/beta/ $S3_BUCKET/$DISTRIBUTION/release/ --cache-control="max-age=0, no-cache"
 done
 
 rm -rf /tmp/beta_upgrade

--- a/build-plugin/sfx_scripts/sign_and_upload_to_beta.sh
+++ b/build-plugin/sfx_scripts/sign_and_upload_to_beta.sh
@@ -78,7 +78,7 @@ do
 	    apt-ftparchive release . > Release
 	    gpg --default-key $DEBIANKEYID -abs -o Release.gpg Release
 	    aws s3 rm --recursive $S3_BUCKET/$DISTRIBUTION/beta/
-	    aws s3 cp --recursive . $S3_BUCKET/$DISTRIBUTION/beta
+	    aws s3 cp --recursive . $S3_BUCKET/$DISTRIBUTION/beta --cache-control="max-age=0, no-cache"
 	fi
 done
 rm -rf /tmp/collectd-ppa-uploads/


### PR DESCRIPTION
I spoke with @tedoc2000 about this a couple of weeks ago.  I think this is what I need to do.  I haven't tested it yet because I wanted you guys to look it over first.  I believe I'll need to do a cloud front invalidation of /debs/* before running these build jobs again.