### PR TITLE
Ensure six dependency is packaged on debian

### DIFF
--- a/build-plugin/debian/deps.sh
+++ b/build-plugin/debian/deps.sh
@@ -5,5 +5,5 @@ tar -xvzf psutil-3.2.2.tar.gz
 tar -xvzf simplejson-3.8.1.tar.gz
 (cd simplejson-3.8.1 && python setup.py build && mv build/lib*/simplejson ../plugins/. )
 
-find venv
-(cd venv/lib/python*/*packages && mv pyformance requests google signalfx ../../../../plugins/. )
+find 
+(cd venv/lib/python*/*packages && mv pyformance requests google signalfx six* ../../../../plugins/.)

--- a/build-plugin/debian/rules
+++ b/build-plugin/debian/rules
@@ -6,5 +6,8 @@ override_dh_install:
 	# verify, don't build broken package
 	python plugins/signalfx_metadata.py once
 
+	# clean up compiled files
+	rm plugins/*.pyc
+
 	find plugins
 	dh_install plugins/*  opt/signalfx-collectd-plugin

--- a/build-plugin/sfx_scripts/cmdseq
+++ b/build-plugin/sfx_scripts/cmdseq
@@ -3,6 +3,11 @@ set -xe
 
 rm -rf /opt/result/*
 OS_ARRAY=("wheezy" "jessie" "precise" "trusty" "vivid" "xenial")
+
+if [ -n $DISTIRIBUTION ] ; then
+  OS_ARRAY=("${DISTRIBUTION}")
+fi
+
 for DISTRIBUTION in ${OS_ARRAY[@]}
 do
   echo "==================================== Building package for $DISTRIBUTION  =============================================="


### PR DESCRIPTION
- Ensure six dependency is packaged on debian

- Remove .pyc files before packaging plugin

- Enable building packages for a single distribution

- Add plugin support to local_build.sh 